### PR TITLE
Remove font-smoothing properties

### DIFF
--- a/styles.json
+++ b/styles.json
@@ -5,8 +5,6 @@
             "lineHeight": 1.2,
             "explicitLineHeight": 44,
             "letterSpacing": 0.02,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -15,8 +13,6 @@
             "lineHeight": 1.2,
             "explicitLineHeight": 34,
             "letterSpacing": 0.02,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -25,8 +21,6 @@
             "lineHeight": 1.25,
             "explicitLineHeight": 28,
             "letterSpacing": 0.014,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -35,8 +29,6 @@
             "lineHeight": 1.25,
             "explicitLineHeight": 23,
             "letterSpacing": 0.015,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -45,8 +37,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 26,
             "letterSpacing": -0.01,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -55,8 +45,6 @@
             "lineHeight": 1.25,
             "explicitLineHeight": 21,
             "letterSpacing": 0.0075,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -65,8 +53,6 @@
             "lineHeight": 1.4,
             "explicitLineHeight": 24,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -75,8 +61,6 @@
             "lineHeight": 1.35,
             "explicitLineHeight": 22,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -85,8 +69,6 @@
             "lineHeight": 1.20,
             "explicitLineHeight": 18,
             "letterSpacing": 0.015,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -95,8 +77,6 @@
             "lineHeight": 1.20,
             "explicitLineHeight": 18,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -105,8 +85,6 @@
             "lineHeight": 1.35,
             "explicitLineHeight": 16,
             "letterSpacing": 0.0025,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -116,8 +94,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 16,
             "letterSpacing": 0.0125,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -126,8 +102,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 14,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -136,8 +110,6 @@
             "lineHeight": 1.2,
             "explicitLineHeight": 13,
             "letterSpacing": 0.01,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         }
@@ -148,8 +120,6 @@
             "lineHeight": 1.15,
             "explicitLineHeight": 86,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -158,8 +128,6 @@
             "lineHeight": 1.15,
             "explicitLineHeight": 86,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -168,8 +136,6 @@
             "lineHeight": 1.15,
             "explicitLineHeight": 64,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -178,8 +144,6 @@
             "lineHeight": 1.2,
             "explicitLineHeight": 54,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 800,
             "width": 100
         },
@@ -188,8 +152,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 55,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -198,8 +160,6 @@
             "lineHeight": 1.25,
             "explicitLineHeight": 45,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -208,8 +168,6 @@
             "lineHeight": 1.35,
             "explicitLineHeight": 39,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -218,8 +176,6 @@
             "lineHeight": 1.35,
             "explicitLineHeight": 42,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -228,8 +184,6 @@
             "lineHeight": 1.20,
             "explicitLineHeight": 35,
             "letterSpacing": 0.004,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -238,8 +192,6 @@
             "lineHeight": 1.20,
             "explicitLineHeight": 35,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -248,8 +200,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 38,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -258,8 +208,6 @@
             "lineHeight": 1.3,
             "explicitLineHeight": 33,
             "letterSpacing": null,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         },
@@ -268,8 +216,6 @@
             "lineHeight": 1.35,
             "explicitLineHeight": 31,
             "letterSpacing": -0.002,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 400,
             "width": 100
         },
@@ -278,8 +224,6 @@
             "lineHeight": 1.2,
             "explicitLineHeight": 28,
             "letterSpacing": 0.02,
-            "webkit-font-smoothing": "antialiased",
-            "moz-osx-font-smoothing": "grayscale",
             "weight": 660,
             "width": 100
         }


### PR DESCRIPTION
## Description
After some consideration, it has been decided that we should not use antialiasing / font smoothing with text styles. This PR removes the `-webkit-font-smoothing` and `-moz-osx-font-smoothing` properties from `styles.json`.