### PR TITLE
Fix visibility warnings

### DIFF
--- a/ios/NRKSansStyle+calculation.swift
+++ b/ios/NRKSansStyle+calculation.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 public extension FontStyle {
-    public var uiFontWeight: UIFont.Weight {
+    var uiFontWeight: UIFont.Weight {
         /// The relationship between the "standard" font weights (the ones that are
         /// used by Figma, web, and Android) and the font weights used by iOS are
         /// not linear. Because the relationship is unknown, we approximate the
@@ -51,7 +51,7 @@ public extension FontStyle {
         return UIFont.Weight(rawValue: CGFloat(weightValue))
     }
 
-    public var lineHeightMultiple: CGFloat? {
+    var lineHeightMultiple: CGFloat? {
         /// The NSAttributedString property 'lineHeightMultiple' is a multiple
         /// of the **DEFAULT** line height, embedded in the font. For NRK Sans, the
         /// default line height is 120% of the point size. So the lineHeightMultiple
@@ -61,7 +61,7 @@ public extension FontStyle {
         return lineHeightEm / 1.2
     }
 
-    public var kerning: CGFloat? {
+    var kerning: CGFloat? {
         /// Kerning/tracking/letter spacing is also using a custom value on iOS (I hope
         /// you're not surprised at this point). Where other platforms use an 'em' property,
         /// iOS uses a value that's fixed to the point size. Multiply the point size with the


### PR DESCRIPTION
Fixes warnings such as:

```
'public' modifier is redundant for property declared in a public extension
```
