### PR TITLE
Remove letter spacing for text style "label"

### DIFF
--- a/styles.json
+++ b/styles.json
@@ -109,7 +109,7 @@
             "size": 11,
             "lineHeight": 1.1,
             "explicitLineHeight": 13,
-            "letterSpacing": 0.1,
+            "letterSpacing": null,
             "weight": 660,
             "width": 100
         },
@@ -239,7 +239,7 @@
             "size": 23,
             "lineHeight": 1.2,
             "explicitLineHeight": 28,
-            "letterSpacing": 0.07,
+            "letterSpacing": null,
             "weight": 660,
             "width": 100
         },


### PR DESCRIPTION
## Description
Removes letter spacing for text style "label" for both responsive screens and TVs. @henrik-mattsson @simenmyklebust @ole-marius 